### PR TITLE
Avoids TypeScript compiler error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,5 +6,5 @@ declare module "react-spinner-material" {
         spinnerWidth?: number;
         show?: boolean;
     }
-    export default class Spinner extends React.Component<SpinnerProps, void> {}
+    export default class Spinner extends React.Component<SpinnerProps, {}> {}
 }


### PR DESCRIPTION
I am getting this error in my project:
```
TS2605: JSX element type 'Spinner' is not a constructor function for JSX elements.
  Types of property 'setState' are incompatible.
    Type '{ <K extends never>(f: (prevState: void, props: SpinnerProps) => Pick<void, K>, callback?: (() =>...' is not assignable to type '{ <K extends never>(f: (prevState: {}, props: any) => Pick<{}, K>, callback?: (() => any) | undef...'.
      Types of parameters 'f' and 'f' are incompatible.
        Type '(prevState: {}, props: any) => Pick<{}, any>' is not assignable to type '(prevState: void, props: SpinnerProps) => Pick<void, any>'.
          Types of parameters 'prevState' and 'prevState' are incompatible.
            Type 'void' is not assignable to type '{}'.
```

Because React defaults the state to {}, which is not void.
I'm on 
- `react` 16.6.1
- `@types/react` 15.0.38
- `typescript` 2.3.4

I believe the state prop should be completely removed, per https://github.com/DefinitelyTyped/DefinitelyTyped/pull/17288 on `@types/react`.
But I didn't remove it in case someone is using this with an older version of `@types/react` that doesn't have the default types in React.Component.
