### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
   ],
   "author": "Chris Sullivan",
   "license": "Unlicense",
-  "peerDependencies": {
-    "react": "^15.6.1"
-  },
   "devDependencies": {
     "@types/react": "^16.8.10",
     "@types/react-dom": "^16.8.3",


### PR DESCRIPTION
React is @16 now, and, is this really a peer dependency, or is this really the right use case for the `peerDependencies` section?  
cf [nodejs.org/npm/ doc ](https://nodejs.org/es/blog/npm/peer-dependencies/#using-peer-dependencies)

I think, if this package is purely css without any dependencies, then it doesn't need to declare that it "goes together with strictly react@15"

Then also, the only effect I think is a warning on production `npm i`,
`npm WARN react-spinner-material@1.1.3 requires a peer of react@^15.6.1 but none is installed. You must install peer dependencies yourself.`

The 2nd contributing factor being in my package.json, that declares dependency `"react": "^16.9.0",` but I think that is a good upgrade otherwise for my application.

Thanks